### PR TITLE
fix: add use_azuread_auth to azurerm backend for OIDC

### DIFF
--- a/.github/skills/terraform-azure/assets/backend.tf
+++ b/.github/skills/terraform-azure/assets/backend.tf
@@ -10,6 +10,7 @@ terraform {
     # storage_account_name = "sttfstate<unique>"
     # container_name       = "tfstate"
     # key                  = "<env>/<stack>.tfstate"
-    use_oidc = true
+    use_oidc         = true
+    use_azuread_auth = true
   }
 }

--- a/.github/skills/terraform-azure/references/backend-setup.md
+++ b/.github/skills/terraform-azure/references/backend-setup.md
@@ -62,6 +62,7 @@ terraform {
     container_name       = "tfstate"
     key                  = "dev/network.tfstate"  # unique per env + stack
     use_oidc             = true
+    use_azuread_auth     = true
   }
 }
 ```
@@ -78,8 +79,9 @@ terraform init \
 
 ## Authentication
 
-- **CI**: authenticate with OIDC (`use_oidc = true`) and set `ARM_CLIENT_ID`,
-  `ARM_TENANT_ID`, `ARM_SUBSCRIPTION_ID` — no client secrets, no storage keys.
+- **CI**: authenticate with OIDC (`use_oidc = true`, `use_azuread_auth = true`)
+  and set `ARM_CLIENT_ID`, `ARM_TENANT_ID`, `ARM_SUBSCRIPTION_ID` — no client
+  secrets, no storage keys.
 - **Local**: `az login`; the backend uses your Entra credentials with
   `use_azuread_auth`/`use_oidc`. Avoid `ARM_ACCESS_KEY`.
 

--- a/docs/gitops/01-create-infrastructure.md
+++ b/docs/gitops/01-create-infrastructure.md
@@ -133,8 +133,9 @@ terraform init \
 ```
 
 Use a unique `key` per environment + stack (e.g. `dev/network.tfstate`). In CI,
-authenticate with OIDC (`use_oidc = true`, `ARM_CLIENT_ID` / `ARM_TENANT_ID` /
-`ARM_SUBSCRIPTION_ID`) — never client secrets or storage keys.
+authenticate with OIDC (`use_oidc = true`, `use_azuread_auth = true`,
+`ARM_CLIENT_ID` / `ARM_TENANT_ID` / `ARM_SUBSCRIPTION_ID`) — never client
+secrets or storage keys.
 
 > State contains secrets in plaintext. Lock down RBAC, keep the account private,
 > and rely on encryption at rest (default). Never commit `*.tfstate`.

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -4,6 +4,7 @@
 
 terraform {
   backend "azurerm" {
-    use_oidc = true
+    use_oidc         = true
+    use_azuread_auth = true
   }
 }


### PR DESCRIPTION
The azurerm backend's OIDC flow requires both `use_oidc = true` and `use_azuread_auth = true`. Without the latter, `terraform init` fails because Azure AD authentication is not enabled for state access.

## Changes

- `infra/backend.tf` — added `use_azuread_auth = true`
- `docs/gitops/01-create-infrastructure.md` — updated docs to mention both flags
- `.github/skills/terraform-azure/assets/backend.tf` — same fix in the template
- `.github/skills/terraform-azure/references/backend-setup.md` — updated reference docs

Fixes #4