### PR TITLE
infra: identity & RBAC for Foundry agent runtime + CI deploy

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -46,6 +46,9 @@ jobs:
             # Feed the same coordinates to the stack's provider variables.
             TF_VAR_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
             TF_VAR_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+            # Object id of the CI deploy principal, granted Foundry Project Manager
+            # so it can publish agents. Set by the OIDC bootstrap script.
+            TF_VAR_ci_deploy_principal_id: ${{ vars.AZURE_CI_PRINCIPAL_ID }}
             # Expose environment *secrets* to Terraform as TF_VAR_* here, e.g.:
             # TF_VAR_db_admin_password: ${{ secrets.DB_ADMIN_PASSWORD }}
         steps:

--- a/docs/gitops/01-create-infrastructure.md
+++ b/docs/gitops/01-create-infrastructure.md
@@ -171,8 +171,12 @@ Each GitHub Environment (`dev`, `prod`) supplies its own configuration, so the
 same workflow targets different subscriptions/settings without code changes:
 
 - **Variables** (non-secret IDs the workflow reads): `AZURE_CLIENT_ID`,
-  `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `TFSTATE_RESOURCE_GROUP`,
-  `TFSTATE_STORAGE_ACCOUNT`, `TFSTATE_CONTAINER`.
+  `AZURE_CI_PRINCIPAL_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`,
+  `TFSTATE_RESOURCE_GROUP`, `TFSTATE_STORAGE_ACCOUNT`, `TFSTATE_CONTAINER`.
+  `AZURE_CI_PRINCIPAL_ID` is the deploy SP's **object id** (distinct from
+  `AZURE_CLIENT_ID`, the app id); it's fed to Terraform as
+  `TF_VAR_ci_deploy_principal_id` so the stack can grant the SP the **Foundry
+  Project Manager** role to publish agents.
 - **Secrets** (e.g. a DB admin password): set on the environment, then surfaced
   to Terraform by mapping them to `TF_VAR_*` in the `env:` block of
   `terraform.yml`.
@@ -207,6 +211,14 @@ REPO="org/other-repo" PROD_REVIEWER="octocat" \
 The script sets the per-environment **variables** but never secrets — add any
 environment secrets your stack needs afterward, and map them to `TF_VAR_*` in
 `terraform.yml`.
+
+> **RBAC note:** the deploy SP is also granted **User Access Administrator**
+> (override with `RBAC_ADMIN_ROLE`) at subscription scope by default
+> (`RBAC_ADMIN_SCOPE`). Plain `Contributor` lacks
+> `Microsoft.Authorization/roleAssignments/write`, so applies that create the
+> Foundry identity/RBAC assignments would otherwise fail. Narrow
+> `RBAC_ADMIN_SCOPE` to the workload resource group(s) once they exist to reduce
+> blast radius.
 
 > Re-running is safe: existing apps, credentials, role assignments, and
 > environments are detected and left in place.

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,6 +11,11 @@ infra/
   scripts/                  Operational scripts (CI/CD OIDC bootstrap, region check)
   modules/                  Reusable, environment-agnostic building blocks
     resource_group/         Derives rg name + policy tags from inputs
+    log_analytics/          Log Analytics workspace (diagnostics sink)
+    application_insights/   Workspace-backed App Insights for telemetry
+    user_assigned_identity/ Agent runtime managed identity
+    ai_foundry/             Foundry account + project + model deployments
+    identity_rbac/          Least-privilege Foundry role assignments
   stacks/                   Deployable composition roots (provider + backend live here)
     platform/               The stack CI plans/applies
       main.tf               Composes modules — no raw resources

--- a/infra/modules/ai_foundry/outputs.tf
+++ b/infra/modules/ai_foundry/outputs.tf
@@ -18,6 +18,11 @@ output "project_name" {
   value       = module.foundry.ai_foundry_project_name["default"]
 }
 
+output "project_principal_id" {
+  description = "Principal ID of the default Foundry project's system-assigned managed identity (the Entra Agent ID anchor)."
+  value       = module.foundry.ai_foundry_project_system_identity_principal_id["default"]
+}
+
 output "openai_endpoint" {
   description = "OpenAI-compatible endpoint for model SDK clients."
   value       = "https://${module.foundry.ai_foundry_name}.cognitiveservices.azure.com/"

--- a/infra/modules/identity_rbac/main.tf
+++ b/infra/modules/identity_rbac/main.tf
@@ -17,6 +17,11 @@ data "azurerm_role_definition" "ci_deploy" {
   role_definition_id = var.ci_deploy_role_definition_id
 }
 
+locals {
+  ci_deploy_principal_id = var.ci_deploy_principal_id == null ? "" : trimspace(var.ci_deploy_principal_id)
+  ci_deploy_enabled      = local.ci_deploy_principal_id != ""
+}
+
 # Agent runtime identity -> Foundry User on the Foundry account (data-plane:
 # call models, use the project at runtime).
 resource "azurerm_role_assignment" "agent_runtime" {
@@ -29,10 +34,10 @@ resource "azurerm_role_assignment" "agent_runtime" {
 # CI deploy principal -> Foundry Project Manager on the Foundry account (publish
 # agents). Conditional so plan/apply works before the principal id is wired in.
 resource "azurerm_role_assignment" "ci_deploy" {
-  count = var.ci_deploy_principal_id != null ? 1 : 0
+  count = local.ci_deploy_enabled ? 1 : 0
 
   scope              = var.foundry_account_id
   role_definition_id = data.azurerm_role_definition.ci_deploy.id
-  principal_id       = var.ci_deploy_principal_id
+  principal_id       = local.ci_deploy_principal_id
   principal_type     = "ServicePrincipal"
 }

--- a/infra/modules/identity_rbac/main.tf
+++ b/infra/modules/identity_rbac/main.tf
@@ -1,0 +1,38 @@
+# Identity & RBAC module.
+#
+# Wires least-privilege, keyless RBAC for the Foundry platform:
+#   - the agent runtime managed identity gets the data-plane role needed to call
+#     models and use the project, and
+#   - the CI deploy principal gets the role required to publish agents.
+#
+# Roles are referenced by definition ID (GUID) rather than name: the Foundry
+# built-in roles were renamed (e.g. "Azure AI User" -> "Foundry User") and the
+# IDs are stable across the rollout.
+
+data "azurerm_role_definition" "agent_runtime" {
+  role_definition_id = var.agent_runtime_role_definition_id
+}
+
+data "azurerm_role_definition" "ci_deploy" {
+  role_definition_id = var.ci_deploy_role_definition_id
+}
+
+# Agent runtime identity -> Foundry User on the Foundry account (data-plane:
+# call models, use the project at runtime).
+resource "azurerm_role_assignment" "agent_runtime" {
+  scope              = var.foundry_account_id
+  role_definition_id = data.azurerm_role_definition.agent_runtime.id
+  principal_id       = var.agent_runtime_principal_id
+  principal_type     = "ServicePrincipal"
+}
+
+# CI deploy principal -> Foundry Project Manager on the Foundry account (publish
+# agents). Conditional so plan/apply works before the principal id is wired in.
+resource "azurerm_role_assignment" "ci_deploy" {
+  count = var.ci_deploy_principal_id != null ? 1 : 0
+
+  scope              = var.foundry_account_id
+  role_definition_id = data.azurerm_role_definition.ci_deploy.id
+  principal_id       = var.ci_deploy_principal_id
+  principal_type     = "ServicePrincipal"
+}

--- a/infra/modules/identity_rbac/outputs.tf
+++ b/infra/modules/identity_rbac/outputs.tf
@@ -1,0 +1,11 @@
+# Outputs for the identity_rbac module.
+
+output "agent_runtime_role_assignment_id" {
+  description = "Resource ID of the agent runtime role assignment."
+  value       = azurerm_role_assignment.agent_runtime.id
+}
+
+output "ci_deploy_role_assignment_id" {
+  description = "Resource ID of the CI deploy role assignment, or null when not configured."
+  value       = one(azurerm_role_assignment.ci_deploy[*].id)
+}

--- a/infra/modules/identity_rbac/variables.tf
+++ b/infra/modules/identity_rbac/variables.tf
@@ -1,0 +1,29 @@
+# Inputs for the identity_rbac module.
+
+variable "foundry_account_id" {
+  type        = string
+  description = "Resource ID of the Foundry (Cognitive Services) account that role assignments are scoped to."
+}
+
+variable "agent_runtime_principal_id" {
+  type        = string
+  description = "Principal (object) ID of the agent runtime managed identity that receives the Foundry data-plane role."
+}
+
+variable "ci_deploy_principal_id" {
+  type        = string
+  description = "Principal (object) ID of the CI deploy service principal that publishes agents. When null, the CI role assignment is skipped."
+  default     = null
+}
+
+variable "agent_runtime_role_definition_id" {
+  type        = string
+  description = "Built-in role definition GUID granted to the agent runtime identity. Defaults to Foundry User (formerly Azure AI User)."
+  default     = "53ca6127-db72-4b80-b1b0-d745d6d5456d"
+}
+
+variable "ci_deploy_role_definition_id" {
+  type        = string
+  description = "Built-in role definition GUID granted to the CI deploy principal. Defaults to Foundry Project Manager (formerly Azure AI Project Manager), the minimum role to publish agents."
+  default     = "eadc314b-1a2d-4efa-be10-5d325db5065e"
+}

--- a/infra/modules/identity_rbac/variables.tf
+++ b/infra/modules/identity_rbac/variables.tf
@@ -12,7 +12,7 @@ variable "agent_runtime_principal_id" {
 
 variable "ci_deploy_principal_id" {
   type        = string
-  description = "Principal (object) ID of the CI deploy service principal that publishes agents. When null, the CI role assignment is skipped."
+  description = "Principal (object) ID of the CI deploy service principal that publishes agents. When null, empty, or whitespace, the CI role assignment is skipped."
   default     = null
 }
 

--- a/infra/modules/identity_rbac/versions.tf
+++ b/infra/modules/identity_rbac/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.9"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/infra/modules/user_assigned_identity/main.tf
+++ b/infra/modules/user_assigned_identity/main.tf
@@ -1,0 +1,23 @@
+# User-assigned managed identity module.
+#
+# Provisions a standalone user-assigned managed identity (id-<workload>-<env>)
+# for the agent runtime / delivery pipeline. It receives the Foundry data-plane
+# role via the identity_rbac module and exposes a stable client_id that workloads
+# (e.g. agent compute the delivery pipeline assigns it to) authenticate as —
+# keyless, no stored credentials.
+
+locals {
+  name_suffix = "${var.workload}-${var.environment}"
+
+  tags = merge(var.tags, {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  })
+}
+
+resource "azurerm_user_assigned_identity" "this" {
+  name                = "id-${local.name_suffix}"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = local.tags
+}

--- a/infra/modules/user_assigned_identity/outputs.tf
+++ b/infra/modules/user_assigned_identity/outputs.tf
@@ -1,0 +1,21 @@
+# Outputs for the user_assigned_identity module.
+
+output "id" {
+  description = "Resource ID of the user-assigned managed identity."
+  value       = azurerm_user_assigned_identity.this.id
+}
+
+output "name" {
+  description = "Name of the user-assigned managed identity."
+  value       = azurerm_user_assigned_identity.this.name
+}
+
+output "principal_id" {
+  description = "Principal (object) ID of the managed identity, used for RBAC role assignments."
+  value       = azurerm_user_assigned_identity.this.principal_id
+}
+
+output "client_id" {
+  description = "Client ID of the managed identity, consumed by the agent runtime / delivery pipeline."
+  value       = azurerm_user_assigned_identity.this.client_id
+}

--- a/infra/modules/user_assigned_identity/variables.tf
+++ b/infra/modules/user_assigned_identity/variables.tf
@@ -1,0 +1,41 @@
+# Inputs for the user_assigned_identity module.
+
+variable "workload" {
+  type        = string
+  description = "Workload name used to derive the identity name (id-<workload>-<environment>)."
+
+  validation {
+    condition     = length(trimspace(var.workload)) > 0
+    error_message = "workload must be a non-empty string."
+  }
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment (e.g. dev, prod). Used to derive the identity name."
+
+  validation {
+    condition     = contains(["dev", "prod"], var.environment)
+    error_message = "environment must be one of: dev, prod."
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the managed identity."
+
+  validation {
+    condition     = length(trimspace(var.location)) > 0
+    error_message = "location must be a non-empty Azure region."
+  }
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group to deploy the identity into."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Base tags applied to the managed identity."
+}

--- a/infra/modules/user_assigned_identity/versions.tf
+++ b/infra/modules/user_assigned_identity/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.9"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/infra/scripts/bootstrap-cicd-oidc.sh
+++ b/infra/scripts/bootstrap-cicd-oidc.sh
@@ -15,6 +15,8 @@
 #   3. Grants the SP RBAC:
 #        - "Storage Blob Data Contributor" on the tfstate storage account
 #        - a deploy role (default Contributor) at subscription scope
+#        - a role-assignment-admin role (default User Access Administrator) at
+#          subscription scope so applies can create Foundry RBAC assignments
 #   4. Creates the GitHub Environments and (for prod) a required reviewer.
 #   5. Sets the per-environment Actions *variables* the workflows read
 #      (AZURE_*, TFSTATE_*). Secrets are intentionally NOT set here.
@@ -36,6 +38,12 @@
 #   SUBSCRIPTION_ID     Default: current `az account show`.
 #   TENANT_ID           Default: current `az account show`.
 #   DEPLOY_ROLE         Subscription-scope role for applies. Default: "Contributor".
+#   RBAC_ADMIN_ROLE     Subscription-scope role that lets applies create role
+#                       assignments. Default: "User Access Administrator".
+#   RBAC_ADMIN_SCOPE    Scope for RBAC_ADMIN_ROLE. Default: the subscription.
+#                       Narrow to the workload resource group(s) once they exist
+#                       to reduce blast radius (the stack's assignments target the
+#                       Foundry account inside rg-<workload>-<env>).
 #   TFSTATE_RESOURCE_GROUP   Default: "rg-tfstate".
 #   TFSTATE_STORAGE_ACCOUNT  Default: "sttfstate31327".
 #   TFSTATE_CONTAINER        Default: "tfstate".
@@ -65,6 +73,8 @@ APPROVAL_ENVS="${APPROVAL_ENVS:-prod}"
 PROD_REVIEWER="${PROD_REVIEWER:-$(gh api user -q .login)}"
 APP_NAME="${APP_NAME:-${REPO##*/}-cicd}"
 DEPLOY_ROLE="${DEPLOY_ROLE:-Contributor}"
+RBAC_ADMIN_ROLE="${RBAC_ADMIN_ROLE:-User Access Administrator}"
+RBAC_ADMIN_SCOPE="${RBAC_ADMIN_SCOPE:-/subscriptions/${SUBSCRIPTION_ID}}"
 
 TFSTATE_RESOURCE_GROUP="${TFSTATE_RESOURCE_GROUP:-rg-tfstate}"
 TFSTATE_STORAGE_ACCOUNT="${TFSTATE_STORAGE_ACCOUNT:-sttfstate31327}"
@@ -76,6 +86,7 @@ log "Tenant:          $TENANT_ID"
 log "Environments:    $ENVIRONMENTS  (approval: $APPROVAL_ENVS)"
 log "App name:        $APP_NAME"
 log "Deploy role:     $DEPLOY_ROLE (subscription scope)"
+log "RBAC admin role: $RBAC_ADMIN_ROLE (scope: $RBAC_ADMIN_SCOPE)"
 log "State account:   $TFSTATE_STORAGE_ACCOUNT / $TFSTATE_CONTAINER (rg: $TFSTATE_RESOURCE_GROUP)"
 [[ "${DRY_RUN:-false}" == "true" ]] && log "DRY_RUN enabled — no changes will be made"
 echo >&2
@@ -151,6 +162,14 @@ run az role assignment create \
   --role "$DEPLOY_ROLE" --scope "/subscriptions/${SUBSCRIPTION_ID}" >/dev/null 2>&1 \
   || warn "deploy RBAC may already exist (ignored)"
 
+# Role-assignment write so applies can create Foundry RBAC assignments
+# (Contributor alone lacks Microsoft.Authorization/roleAssignments/write).
+log "Granting '$RBAC_ADMIN_ROLE' at scope $RBAC_ADMIN_SCOPE"
+run az role assignment create \
+  --assignee-object-id "$SP_OID" --assignee-principal-type ServicePrincipal \
+  --role "$RBAC_ADMIN_ROLE" --scope "$RBAC_ADMIN_SCOPE" >/dev/null 2>&1 \
+  || warn "rbac-admin RBAC may already exist (ignored)"
+
 # --- 4 & 5. GitHub environments, reviewers, and variables --------------------
 in_list() { local n="$1"; shift; for x in $*; do [[ "$x" == "$n" ]] && return 0; done; return 1; }
 
@@ -180,6 +199,7 @@ for env in $ENVIRONMENTS; do
       && log "  var $1 set" || warn "  failed to set var $1"
   }
   set_var AZURE_CLIENT_ID "$APP_ID"
+  set_var AZURE_CI_PRINCIPAL_ID "$SP_OID"
   set_var AZURE_TENANT_ID "$TENANT_ID"
   set_var AZURE_SUBSCRIPTION_ID "$SUBSCRIPTION_ID"
   set_var TFSTATE_RESOURCE_GROUP "$TFSTATE_RESOURCE_GROUP"

--- a/infra/stacks/platform/main.tf
+++ b/infra/stacks/platform/main.tf
@@ -45,6 +45,18 @@ module "application_insights" {
   tags                       = var.tags
 }
 
+# --- Identity ---
+
+module "user_assigned_identity" {
+  source = "../../modules/user_assigned_identity"
+
+  workload            = "terminal-velocity"
+  environment         = var.environment
+  location            = var.location
+  resource_group_name = module.resource_group.name
+  tags                = var.tags
+}
+
 # --- AI Foundry ---
 
 module "ai_foundry" {
@@ -63,4 +75,17 @@ module "ai_foundry" {
   application_insights_connection_string = module.application_insights.connection_string
 
   model_deployments = var.model_deployments
+}
+
+# --- Identity & RBAC ---
+#
+# Least-privilege, keyless RBAC: the agent runtime identity gets the Foundry
+# data-plane role; the CI deploy principal gets the role to publish agents.
+
+module "identity_rbac" {
+  source = "../../modules/identity_rbac"
+
+  foundry_account_id         = module.ai_foundry.foundry_id
+  agent_runtime_principal_id = module.user_assigned_identity.principal_id
+  ci_deploy_principal_id     = var.ci_deploy_principal_id
 }

--- a/infra/stacks/platform/outputs.tf
+++ b/infra/stacks/platform/outputs.tf
@@ -55,3 +55,30 @@ output "openai_endpoint" {
   description = "OpenAI-compatible endpoint for model SDK clients."
   value       = module.ai_foundry.openai_endpoint
 }
+
+# --- Identity & RBAC ---
+
+output "agent_runtime_identity_id" {
+  description = "Resource ID of the agent runtime user-assigned managed identity."
+  value       = module.user_assigned_identity.id
+}
+
+output "agent_runtime_principal_id" {
+  description = "Principal (object) ID of the agent runtime managed identity."
+  value       = module.user_assigned_identity.principal_id
+}
+
+output "agent_runtime_client_id" {
+  description = "Client ID of the agent runtime managed identity for the delivery pipeline / agent SDK."
+  value       = module.user_assigned_identity.client_id
+}
+
+output "foundry_project_principal_id" {
+  description = "Principal ID of the Foundry project's system-assigned identity (the Entra Agent ID anchor)."
+  value       = module.ai_foundry.project_principal_id
+}
+
+output "ci_deploy_principal_id" {
+  description = "Object ID of the CI deploy principal granted the agent-publish role, or null when not configured."
+  value       = var.ci_deploy_principal_id
+}

--- a/infra/stacks/platform/variables.tf
+++ b/infra/stacks/platform/variables.tf
@@ -37,6 +37,12 @@ variable "tags" {
   description = "Tags applied to all resources. Must satisfy subscription policy (Owner, Purpose, BillingCode)."
 }
 
+variable "ci_deploy_principal_id" {
+  type        = string
+  description = "Object (principal) ID of the CI deploy service principal granted the Foundry Project Manager role to publish agents. Fed by TF_VAR_ci_deploy_principal_id (AZURE_CI_PRINCIPAL_ID) in CI. When null, the CI role assignment is skipped."
+  default     = null
+}
+
 variable "model_deployments" {
   type = map(object({
     name = string


### PR DESCRIPTION
## What

Implements **#30** (child of epic #14) — declarative, keyless, least-privilege identity & RBAC for the Microsoft Foundry platform.

## Approach

Grounded in current Microsoft Foundry docs ([RBAC](https://learn.microsoft.com/en-us/azure/foundry/concepts/rbac-foundry), [agent identity](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/agent-identity)):

- **`modules/user_assigned_identity`** (new) — a standalone managed identity `id-<workload>-<env>` for the agent runtime / delivery pipeline. Exposes `principal_id` and a stable `client_id`.
- **`modules/identity_rbac`** (new) — grants:
  - the runtime identity → **Foundry User** on the Foundry account (data-plane: call models / use the project)
  - the CI deploy principal → **Foundry Project Manager** (publish agents)
  
  Roles are referenced by **definition GUID** (the Foundry roles were recently renamed from the `Azure AI *` names). The CI assignment is **conditional** on the principal id being supplied, so plan/validate work before it's wired in.
- **`modules/ai_foundry`** — new `project_principal_id` output (the project's system-assigned identity, which is the Entra Agent ID anchor for the hosted runtime).
- **Platform stack** — composes the new modules, adds `ci_deploy_principal_id` input and identity outputs for the delivery pipeline.
- **CI + bootstrap** — workflow feeds `AZURE_CI_PRINCIPAL_ID` as `TF_VAR_ci_deploy_principal_id`; bootstrap publishes the deploy SP's object id and grants it role-assignment write (configurable `RBAC_ADMIN_ROLE` / `RBAC_ADMIN_SCOPE`) so applies can create the Foundry RBAC assignments.

## Design notes

- We deliberately use **Foundry** roles, not `Cognitive Services *` / `Azure AI Developer` — current docs say those don't apply to Foundry agent/project scenarios.
- The UAMI is **not** attached to the AVM Foundry account's identity block: the AVM module resolves attached identities via `for_each` over their resource IDs, which breaks a greenfield `plan` (the id is unknown until apply). Keeping the identity standalone + role-assigned preserves a clean one-shot CI apply.

## Acceptance criteria

- [x] Managed identity for the agent runtime with the minimal Foundry roles
- [x] Role assignment for the OIDC CI principal to publish agents
- [x] No secrets/keys — Entra/OIDC + managed identity only
- [x] Outputs principal/client ids needed by the delivery pipeline
- [x] `terraform fmt` + `validate` clean

## Test

- `terraform fmt -recursive -check` ✅
- `terraform init -backend=false && terraform validate` ✅ (only pre-existing upstream AVM Cosmos deprecation warnings)
- `bash -n` on the bootstrap script ✅

Closes #30