### PR TITLE
docs(gitops): GitOps IaC/CICD roadmap and phase outlines

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -2,25 +2,46 @@ name: Infra CI
 
 # Pull-request gate: format, validate, and plan the infra stack against dev.
 # Plan-only — never applies from a PR. The plan is the review artifact.
+#
+# The workflow runs on every PR so the required "Infra CI" check is always
+# reported (a path-filtered trigger would leave non-infra PRs stuck on
+# "Expected — Waiting for status to be reported"). Change detection gates the
+# expensive plan job; the aggregate `infra-ci` job reports the required context
+# whether or not infra files changed.
 
 on:
     pull_request:
-        paths:
-            - "infra/**"
-            - ".github/workflows/infra-ci.yml"
-            - ".github/workflows/terraform.yml"
 
 permissions:
     id-token: write
     contents: read
+    pull-requests: read
 
 concurrency:
     group: infra-ci-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
+    changes:
+        name: Detect infra changes
+        runs-on: ubuntu-latest
+        outputs:
+            infra: ${{ steps.filter.outputs.infra }}
+        steps:
+            - name: Filter paths
+              id: filter
+              uses: dorny/paths-filter@v3
+              with:
+                  filters: |
+                      infra:
+                        - 'infra/**'
+                        - '.github/workflows/infra-ci.yml'
+                        - '.github/workflows/terraform.yml'
+
     plan-dev:
         name: Plan (dev)
+        needs: changes
+        if: ${{ needs.changes.outputs.infra == 'true' }}
         uses: ./.github/workflows/terraform.yml
         with:
             environment: dev
@@ -28,20 +49,26 @@ jobs:
         secrets: inherit
 
     # Aggregate gate that reports a stable "Infra CI" check-run context for branch
-    # protection. The reusable-workflow job above surfaces as "Plan (dev) /
-    # terraform (dev)", which never matches the required "Infra CI" context, so
-    # this job provides it and fails unless the plan succeeded.
+    # protection. It always runs: it passes when no infra files changed (nothing
+    # to plan) and otherwise requires the plan to have succeeded.
     infra-ci:
         name: Infra CI
-        needs: plan-dev
+        needs: [changes, plan-dev]
         if: ${{ always() }}
         runs-on: ubuntu-latest
         steps:
-            - name: Verify plan succeeded
+            - name: Verify plan gate
               run: |
+                  changed="${{ needs.changes.outputs.infra }}"
                   result="${{ needs.plan-dev.result }}"
+                  echo "infra changed: $changed"
                   echo "plan-dev result: $result"
+                  if [ "$changed" != "true" ]; then
+                      echo "No infra changes in this PR; Infra CI gate passes without planning."
+                      exit 0
+                  fi
                   if [ "$result" != "success" ]; then
                       echo "::error::Infra CI gate failed because plan-dev did not succeed (result: $result)."
                       exit 1
                   fi
+                  echo "Infra changes planned successfully."

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This documentation is structured as two main sections: **GitOps for Agents** and
 
 ## GitOps for Agents
 
-This is the primary point of the reference implementation: demonstrating how to use GitOps principles to manage and deploy agents effectively. This section includes:
+This is the primary point of the reference implementation: demonstrating how to use GitOps principles to manage and deploy agents effectively. See the [GitOps section](./gitops/README.md) for the full reading order, and the [GitOps roadmap & gap analysis](./gitops/roadmap.md) for where we are versus the reference posts. This section includes:
 
 - **Agent Deployment:** Step-by-step guides on deploying agents using GitOps workflows.
 - **Configuration Management:** Best practices for managing agent configurations through Git repositories.

--- a/docs/gitops/03-agent-delivery-pipeline.md
+++ b/docs/gitops/03-agent-delivery-pipeline.md
@@ -1,0 +1,92 @@
+# 03 — Agent Delivery Pipeline (CI/CD → Foundry)
+
+> Outline + bullets. Builds the **agent** GitOps loop that mirrors the infra loop
+> (`terraform.yml` / `infra-ci` / `infra-cd`). Tracks epic #9 and children
+> #17, #15, #28, #27, #21.
+
+## Goal
+
+- Ship a Foundry agent through Git: PR builds + evaluates a candidate, merge
+  promotes it **dev → prod** via OIDC, prod gated by a required reviewer.
+- Establish the pipe with a **placeholder agent** so it's provably green before
+  the real walking-skeleton agent exists.
+
+## The deployment unit: an immutable agent version
+
+- One artifact bundles: container **image digest** (not tag), model deployment
+  binding, `agent.yaml` config, env vars, CPU/memory, declared protocols.
+- **Build once, promote the same digest** across environments — never rebuild per
+  env.
+- Platform **deduplicates** identical versions — treat "no new version" as
+  success, reuse the version id.
+
+## Repository shape (target)
+
+```
+src/
+  agents/<name>/
+    Dockerfile
+    agent.yaml            # name, container, protocols, env, metadata(source_commit)
+    src/
+    evals/                # dataset.jsonl + graders.yaml (see doc 04)
+  tools/
+scripts/
+  deploy_agent_version.py # build → push by digest → create version → emit manifest
+  promote_version.py      # promote a version between environments
+  run_evals.py            # see doc 04
+.github/workflows/
+  agent-ci.yml            # PR gate (#17)
+  agent-deploy.yml        # reusable, env-parameterized (#15)
+  agent-cd.yml            # dev → prod promotion (#28)
+```
+
+## Workflows
+
+### `agent-ci.yml` — PR gate (#17)
+
+- Triggers on PRs touching `src/agents/**` or `src/tools/**`.
+- Steps: Python 3.14 setup → install → `ruff` lint → type-check →
+  `agent.yaml` schema validation → unit/tool tests.
+- Fast, **no Azure credentials** (no deploy). Required check on PRs.
+- Later: build candidate at `--traffic 0` and run evals (doc 04).
+
+### `agent-deploy.yml` — reusable deploy (#15)
+
+- `workflow_call`, environment-parameterized (mirror `terraform.yml`).
+- OIDC via `azure/login`; no secrets/keys.
+- `az acr build` (or `docker build`) → push → capture **digest** →
+  Foundry SDK/`azd` create version → smoke-validate.
+- Emits `deployment-manifest.json` (agent id, version id, digest, source SHA,
+  eval-dataset hash).
+
+### `agent-cd.yml` — promotion (#28)
+
+- On merge to `main`: `deploy-dev` (apply) → `deploy-prod` (`needs` dev,
+  `environment: prod` required reviewer).
+- Calls `agent-deploy.yml` per environment from the **same manifest/digest**.
+- **Eval gate stubbed** here as a no-op; implemented in doc 04 (#11).
+
+## Versioning, outputs & rollback (#27)
+
+- Version derived from Git SHA/tag, stamped on the deployed agent.
+- Deployment summary (agent id, version, env, digest) to the job summary.
+- Keep the last two known-good versions live; **rollback = switch active
+  version / traffic weight**, not a redeploy. Test it before an incident.
+
+## Prerequisites / dependencies
+
+- Foundry infra (epic #14) — account/project/model + CI deploy identity.
+- **ACR** to hold agent images (gap — see [roadmap](./roadmap.md)).
+- Walking-skeleton agent (epic #12) is delivered *through* this pipe.
+
+## Acceptance (pipe is green)
+
+- [ ] PR on `src/**` runs CI and blocks on failure.
+- [ ] Merge deploys a placeholder agent to dev, then prod after approval.
+- [ ] A release maps back to a Git SHA via the manifest.
+- [ ] Rollback exercised in a non-prod environment.
+
+## Runbook (#21)
+
+- Day-to-day: open PR → review eval/plan output → merge → approve prod.
+- Incident: how to roll back, where the manifest/version history lives.

--- a/docs/gitops/04-evaluations-and-guardrails.md
+++ b/docs/gitops/04-evaluations-and-guardrails.md
@@ -1,0 +1,75 @@
+# 04 — Evaluations & Guardrails as CI Gates
+
+> Outline + bullets. Turns agent quality and safety into **blocking gates** in
+> the delivery pipeline (doc 03). Tracks placeholder epic #11. This is the step
+> the reference posts call *the* core difference between agent CI/CD and
+> traditional CI/CD.
+
+## Goal
+
+- No agent version is promoted unless it passes evaluation and safety gates.
+- Fill the eval gate stubbed in `agent-cd.yml` (#28).
+- Treat the eval suite like unit tests: **a failure stops the pipeline.**
+
+## The golden dataset (first-class artifact)
+
+- 20–50 JSONL scenarios: input + reference answer / must-include facts / rubric.
+- Versioned in `src/agents/<name>/evals/dataset.jsonl`; its hash is recorded in
+  the deployment manifest.
+- **Maintained as the agent evolves** — stale datasets give misleading pass/fail.
+
+## Graders
+
+- Foundry built-in evaluators: exact match, similarity, LLM-as-judge,
+  groundedness, safety.
+- **Pin the grader's model deployment** to prevent grader drift.
+- Defined in `evals/graders.yaml`.
+
+## Thresholds (start from P2, tune from an advisory phase)
+
+| Category | Metric | CI (dev) | Prod gate |
+| --- | --- | --- | --- |
+| Quality | Hallucination rate | < 5% | < 3% |
+| Quality | Task completion | > 90% | > 95% |
+| Safety | Grounded response rate | > 95% | > 98% |
+| Safety | Policy violations | 0 | 0 |
+| Performance | p95 latency | < 4000 ms | < 3000 ms |
+| Cost | Tokens / query | track | alert > 20% regression |
+
+- **Hard floors** on safety/groundedness/policy (any regression fails).
+- **Relative** floor on quality (no more than X% drop vs. last-known-good).
+
+## Guardrails (safety plane)
+
+- Content-safety filters on the model deployment; "0 policy violations" is a
+  hard gate.
+- Azure Policy / governance checks that block deployment automatically.
+- Least-privilege RBAC + Entra Agent Identity per version (already in infra).
+
+## Red teaming (adversarial gate)
+
+- Curated adversarial / jailbreak / prompt-injection suite, run on a schedule
+  and before prod promotion.
+- Tooling options: Azure AI Red Teaming Agent / PyRIT-style scans.
+- Failures open a tracked issue (feeds the hill-climbing loop, doc 06).
+
+## Wiring into CI/CD
+
+- **PR (CI)**: build candidate at `--traffic 0` → `run_evals.py` →
+  `check_eval_gates.py` (exit 1 on failure) → advisory at first, then blocking.
+- **Pre-promotion (CD)**: re-run against a stricter scenario set before prod.
+- Both report results to the PR / job summary so reviewers see the diff.
+
+## Phased rollout
+
+1. Advisory evals (collect signal, no blocking).
+2. Flip to blocking with tuned thresholds.
+3. Add safety/policy hard gates.
+4. Add scheduled red-team suite.
+
+## Acceptance
+
+- [ ] Golden dataset + graders committed and hashed into the manifest.
+- [ ] `check_eval_gates.py` fails CI on threshold breach.
+- [ ] Policy-violation gate blocks promotion.
+- [ ] Red-team suite runs on a schedule and on prod promotion.

--- a/docs/gitops/05-slos-and-continuous-eval.md
+++ b/docs/gitops/05-slos-and-continuous-eval.md
@@ -1,0 +1,58 @@
+# 05 — SLOs & Continuous Evaluation
+
+> Outline + bullets. Uses the observability substrate from the infra epic
+> (Log Analytics + App Insights) to define SLOs, surface them, and evaluate the
+> agent **continuously in production**. Tracks placeholder epic #13.
+
+## Goal
+
+- Define SLOs for the agent, surface them on dashboards, and run scheduled
+  evaluation against real prod traffic so regressions are caught after deploy,
+  not just before.
+- Provide the breach signal that drives the hill-climbing loop (doc 06).
+
+## SLOs (starting set)
+
+- **Task success rate** (per package-delivery scenario / SLA tier).
+- **Latency** — p95 end-to-end response time.
+- **Cost** — tokens per query / cost per resolved request.
+- **Safety** — grounded-response rate, policy violations (= 0).
+
+## Per-version telemetry (prerequisite)
+
+- Stamp every request span with: agent name, **version id**, image **digest**
+  (short), model deployment name.
+- Slice every metric by version id — essential during traffic splits where two
+  versions serve at once.
+- Alert on **shape, not just rate**: a jump in avg response length or a drop in
+  tool-invocation frequency often precedes a quality regression.
+
+## Dashboards
+
+- App Insights / Log Analytics workbooks: SLO tiles, per-version error/latency,
+  cost dimensions (tag traces with tenant/customer where relevant).
+- Sandbox right-sizing signals: CPU/memory peaks vs. allocation per version.
+
+## Continuous evaluation
+
+- Sample a % of prod conversations → offline grading on a schedule (reuse the
+  golden graders from doc 04) → **drift detector** vs. last-known-good baseline.
+- Run as a scheduled GitHub Actions / Foundry job; emit results to App Insights.
+
+## Alerting
+
+- Azure Monitor alerts when an SLO is at risk (error rate, p95 latency, drift,
+  cost regression > threshold).
+- A breached SLO is the trigger for doc 06's semi-automated loop.
+
+## Acceptance
+
+- [ ] SLOs defined and documented with targets.
+- [ ] Per-version attributes on all traces.
+- [ ] Workbook(s) showing SLOs + per-version slices.
+- [ ] Scheduled continuous-eval job with drift alerting.
+
+## Dependencies
+
+- Observability (infra epic #14) — wired.
+- Evaluations & graders (doc 04 / #11).

--- a/docs/gitops/06-hill-climbing.md
+++ b/docs/gitops/06-hill-climbing.md
@@ -1,0 +1,54 @@
+# 06 — Semi-Automated Hill-Climbing Loop
+
+> Outline + bullets. Closes the GitOps loop from the
+> [philosophy](./00-philosophy.md): an SLO breach automatically becomes an issue,
+> an agent is assigned to investigate and propose a fix, and a human approves the
+> promotion. Tracks placeholder epic #10 — the furthest-out horizon.
+
+## Goal
+
+- Make improvement continuous and mostly automated while keeping a human in the
+  loop for promotion.
+- "We only step downhill (rollback) with good reason." Every change is a step;
+  promote → measure attributed delta → keep or roll back.
+
+## The loop
+
+1. **Breach** — a prod SLO/eval/drift alert fires (doc 05).
+2. **File** — automation opens a GitHub issue with context: failing traces,
+   eval diffs, the version id/digest in play.
+3. **Assign** — an agent is assigned to triage and propose a change
+   (prompt/tool/model lever). A prompt optimizer / Agent Optimizer can suggest
+   instruction edits.
+4. **PR** — the proposed change flows through the normal agent pipeline (docs
+   03–04): build candidate at 0% traffic, run evals + guardrails + red team.
+5. **Human approval** — required reviewer approves promotion to prod.
+6. **Canary & attribute** — promote behind a traffic split; measure the delta
+   against control; keep or roll back.
+
+## Attribution discipline (from the feature notes)
+
+- **One step in flight** at a time across the system — concurrent promotions
+  destroy attribution.
+- Evals must score the **system objective**, not per-component local objectives
+  (avoid Goodhart / local optima).
+- Escalation guard: N consecutive rollbacks on a slice → gate that slice and tell
+  a human its thresholds may no longer match reality.
+
+## What this needs first
+
+- SLOs + continuous eval + drift alerting (doc 05).
+- A green agent pipeline with eval/guardrail gates and tested rollback
+  (docs 03–04).
+- Issue templates + automation (Actions / Foundry) to file and assign.
+
+## Acceptance
+
+- [ ] SLO breach auto-files an issue with traces + failing evals.
+- [ ] Agent auto-assignment proposes a change via PR.
+- [ ] Promotion requires human approval and runs the full gate set.
+- [ ] Canary attribution + rollback decision is recorded.
+
+## Status
+
+Placeholder, furthest horizon. Depends on docs 03–05 being green.

--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -1,0 +1,47 @@
+# GitOps for Agents
+
+The primary reference implementation: managing and deploying Microsoft Foundry
+agents the GitOps way. Git is the source of truth for infrastructure,
+application code, configuration, and deployment. Changes flow through pull
+requests and roll out through GitHub Actions using OIDC — no long-lived secrets,
+fully auditable.
+
+> Scope note: this section is intentionally narrowed to the **GitOps surface —
+> Infrastructure as Code (Terraform) and CI/CD (GitHub Actions)**. Domain
+> features (the package-delivery agents) live under [`docs/app`](../app/notes.md).
+
+## Reading order
+
+| Doc | Status | Covers |
+| --- | --- | --- |
+| [00 — Philosophy](./00-philosophy.md) | written | Hill-climbing, semi-automated improvement, evals/guardrails, human-in-the-loop |
+| [01 — Create the infrastructure](./01-create-infrastructure.md) | written | State backend bootstrap, OIDC trust, infra CI/CD loop |
+| [02 — Modules](./02-modules.md) | written | Foundry platform modules, backend config, plan/verify |
+| [03 — Agent delivery pipeline](./03-agent-delivery-pipeline.md) | outline | Build → version → eval → deploy → promote an agent to Foundry |
+| [04 — Evaluations & guardrails](./04-evaluations-and-guardrails.md) | outline | Eval suites, safety guardrails, red teaming as CI gates |
+| [05 — SLOs & continuous evaluation](./05-slos-and-continuous-eval.md) | outline | SLOs, dashboards, scheduled eval against prod traffic |
+| [06 — Hill-climbing loop](./06-hill-climbing.md) | outline | SLO-breach → issue → agent-assisted fix → human-approved promotion |
+| [Roadmap & gap analysis](./roadmap.md) | outline | Where we are vs. the reference posts, sequenced next steps |
+
+## The GitOps loops
+
+Two delivery loops, same shape (PR plans, merge promotes, prod is gated):
+
+- **Infra loop** — `infra/**` changes → `infra-ci.yml` (plan on PR) →
+  `infra-cd.yml` (apply dev → prod with approval). **Built today.**
+- **Agent loop** — `src/agents|tools/**` changes → `agent-ci.yml`
+  (lint/type/build/eval on PR) → `agent-cd.yml` (deploy dev → prod with
+  approval). **On the roadmap.**
+
+## Source material
+
+The implementation draws on four Microsoft Foundry posts (see
+[roadmap.md](./roadmap.md) for how each maps to our work):
+
+- **Primary** — *DevOps for Microsoft Hosted Agents: From Terraform Apply to
+  Production-Grade Agent Delivery.*
+- *CI/CD for AI Agents on Microsoft Foundry.*
+- *Building and Operating a Microsoft Foundry Hosted Agent with GitOps and
+  GitHub Tasks.*
+- *Infrastructure as Code for AI: Building and Deploying Microsoft Hosted Agents
+  with Terraform.*

--- a/docs/gitops/roadmap.md
+++ b/docs/gitops/roadmap.md
@@ -1,0 +1,114 @@
+# GitOps Roadmap & Gap Analysis
+
+> Outline + bullets. Scope: **IaC + CI/CD only.** Voice and prose to be smoothed
+> later. Reviewed against the four Microsoft Foundry reference posts (P1 primary,
+> P2–P4 supporting).
+
+## 1. Where we are today
+
+### Built (infra GitOps loop is real)
+
+- **Modular Terraform** under `infra/modules/*` composed by a `platform` stack —
+  ahead of P4's flat layout; matches P4's "modular design" best practice.
+- **New Foundry resource model** via the AVM `avm-ptn-aiml-ai-foundry` pattern
+  (`azurerm_cognitive_account` kind `AIServices` + project), not the legacy Hub
+  model — the thing all four posts insist on.
+- **Keyless OIDC** end to end: `azure/login` + `ARM_USE_OIDC`, value-free
+  `backend.tf`, per-env state key `<env>/terminal-velocity.tfstate`.
+- **Infra CI/CD**: `infra-ci.yml` (plan-only on PR) → `infra-cd.yml` (apply dev →
+  prod, prod gated by required reviewer) via reusable `terraform.yml`.
+- **Observability substrate**: Log Analytics + Application Insights wired with
+  diagnostics from day one.
+- **Least-privilege identity**: agent-runtime UAMI + CI deploy principal, roles
+  by stable definition ID.
+
+### Not yet built (the agent GitOps loop)
+
+Everything past `terraform apply` — the entire P1/P2/P3 core — is still issues,
+not code. See gaps below.
+
+## 2. Gap analysis vs. the reference posts
+
+Legend: ✅ done · 🟡 partial/captured as issue · ❌ missing (and whether tracked).
+
+### Infrastructure as Code
+
+| Capability | Source | Status | Notes |
+| --- | --- | --- | --- |
+| New-model Foundry account + project | P1, P4 | ✅ | via AVM module |
+| Modular, env-parameterized Terraform | P4 | ✅ | modules + `platform` stack |
+| Remote state, OIDC, per-env key | P1–P4 | ✅ | |
+| Model deployment in Terraform | P4 | ✅ | `gpt-4.1-mini` GlobalStandard |
+| Runtime + CI identity & RBAC | P4 | ✅ | `identity_rbac` module |
+| **Azure Container Registry (ACR)** | P1, P2 | 🟡 #35 | Hosted-agent images need an ACR (`admin_enabled=false`) + `AcrPull` to the project identity. No ACR module exists yet. |
+| **`terraform plan` as sticky PR comment** | P1, P4 | 🟡 #2 | Captured; not implemented. Posts treat the plan as the review artifact. |
+| **Drift detection job** (`plan -refresh-only` on a schedule) | P4 | 🟡 #44 | Recommended by P4; nothing scheduled yet. |
+| Agent definition in Terraform | P1, P4 | n/a | Posts explicitly say agent versions are **not** Terraform's job — keep them in the agent pipeline (script/SDK). |
+| Private networking (VNet/PE) | P4 | 🟡 | `ai_foundry` exposes `create_private_endpoints`; deferred, fine for skeleton. |
+
+### CI/CD — agent delivery
+
+| Capability | Source | Status | Notes |
+| --- | --- | --- | --- |
+| Epic: agent delivery pipeline | P1–P3 | 🟡 #9 | umbrella |
+| Agent CI (lint/type/build) on `src/**` PRs | P2, P3 | 🟡 #17 | add `ruff`, type-check, `agent.yaml` schema validation |
+| Reusable agent-deploy workflow (OIDC) | P1–P3 | 🟡 #15 | mirror `terraform.yml` shape |
+| CD dev → prod + approval gate | P1–P3 | 🟡 #28 | mirror `infra-cd.yml`; eval gate stubbed |
+| Version/tagging + deployment outputs | P1 | 🟡 #27 | should pin by **image digest**, emit `deployment-manifest.json` (agent id, version, digest, source SHA, eval-dataset hash) |
+| **Build once, promote same artifact** | P1, P3 | 🟡 #39 | "promote the digest, never rebuild per env" as an explicit pipeline rule. |
+| **Tested rollback workflow** | P1–P3 | 🟡 #39 | Keep last 2 known-good versions live; rollback = switch active version / traffic weight; test before an incident. |
+| **CODEOWNERS** for `src/prompts|agents`, `infra/**` | P3 | 🟡 #37 | Enforce review by path. |
+| **Prompt-based agent path** (no build) | P2 | 🟡 #43 | Decision: ship **both** hosted + prompt-based agents. Prompt-based = versioned YAML/config bundle. |
+| **Model-version upgrade playbook** | P1 | ❌ **untracked** | PR changes only the model deployment name/version → full eval at 0% traffic → canary. Doc-only follow-up. |
+| Two environments (dev/prod) | P1, P2 | ✅ **decided** | This demo uses **dev → prod** (no staging); lean on canary in prod. |
+
+### Evaluations, guardrails, observability (hill-climbing)
+
+| Capability | Source | Status | Notes |
+| --- | --- | --- | --- |
+| Eval suite as blocking CI gate | P1, P2 | 🟡 #11 | concrete thresholds exist (P2): hallucination, task-completion, groundedness, p95 latency, policy violations |
+| Golden eval dataset as first-class artifact | P1, P2 | 🟡 #36 | 20–50 JSONL scenarios + graders; pin grader model |
+| Safety guardrails / content safety / policy gate | P2, P4 | 🟡 #42 | "0 policy violations" hard gate |
+| **Red teaming** (adversarial/jailbreak suite) | (extends posts) | 🟡 #38 | Scheduled adversarial eval; PyRIT / AI Red Teaming Agent |
+| SLOs + dashboards | P1, P3 | 🟡 #13 | latency / task-success / cost; App Insights workbooks |
+| Continuous eval on sampled prod traffic | P1, P2 | 🟡 #13 | scheduled offline grading + drift detector |
+| Per-version telemetry (version id/digest on spans) | P1 | 🟡 #41 | Essential during traffic splits. |
+| SLO-breach → issue → agent-assisted fix | P1 | 🟡 #10 | the philosophy's semi-automated loop |
+
+## 3. Proposed sequencing (hill-climbing steps)
+
+Each step is the smallest change that leaves both loops provably green before the
+next. Mirrors P1's maturity ladder, scoped to GitOps.
+
+1. **Close the IaC gaps** — add ACR module (+ `AcrPull`), `plan` PR-comment (#2),
+   scheduled drift detection, CODEOWNERS. *(unblocks the container path; cheap.)*
+2. **Stand up the agent pipeline skeleton (#9)** — `agent-ci.yml` (#17) → reusable
+   `agent-deploy.yml` (#15) → `agent-cd.yml` dev→prod + approval (#28), validated
+   with a placeholder agent. Eval gate is a **no-op stub** here.
+3. **Versioning & rollback (#27 + new)** — digest-pinned versions,
+   `deployment-manifest.json`, build-once/promote-same, tested rollback.
+4. **Evals advisory → blocking (#11)** — golden dataset + graders; run advisory
+   first, then flip to a blocking gate with P2's thresholds.
+5. **Guardrails + red teaming (#11)** — content-safety/policy hard gate (0
+   violations); scheduled adversarial red-team eval.
+6. **SLOs + continuous eval (#13)** — per-version telemetry, workbooks, scheduled
+   prod-traffic grading with drift alerts.
+7. **Semi-automated hill-climbing (#10)** — SLO breach auto-files an issue with
+   traces/failing evals, assigns an agent to propose a fix, human approves
+   promotion. "Only step downhill (rollback) with good reason."
+
+## 4. Decisions & open questions
+
+**Decided**
+- **Environments** — **dev → prod** (2 environments) for this demo. No staging;
+  rely on canary in prod.
+- **Agent types** — ship **both** hosted (container + ACR, #35/#9) and
+  prompt-based (YAML/config bundle, #43) agents.
+- **Self-hosting** — tracked as a spike (#40); out of scope for the initial demo.
+
+**Still open**
+- **azd vs. Foundry SDK script** for version create/promote — #15/#27 assume a
+  script (`deploy_agent_version.py`); confirm.
+- **Toolboxes (P3)** — adopt versioned, centrally-governed tool bundles now or
+  later? Affects how `src/tools` is wired.
+- **Model-version upgrade playbook** — capture as a doc/runbook (untracked).


### PR DESCRIPTION
## Why

We're planning the roadmap for Terminal Velocity's GitOps surface. The infra delivery loop (Terraform + OIDC CI/CD) is mature, but everything past `terraform apply` (the agent delivery loop, evals, guardrails, SLOs, hill-climbing) lived only in placeholder epics. This PR captures that plan as docs so the backlog and the reference posts line up.

## What

Outlines and bullets only (voice/prose to be smoothed later), scoped to **IaC + CI/CD**:

- Fills the empty `docs/gitops/README.md` with the section index and the two delivery loops (infra loop built, agent loop on the roadmap).
- Adds `docs/gitops/roadmap.md` — the core artifact: a gap analysis of the current implementation and the open issues against the four Microsoft Foundry reference posts, a sequenced set of hill-climbing steps, and recorded decisions.
- Adds four phase outlines: `03-agent-delivery-pipeline`, `04-evaluations-and-guardrails`, `05-slos-and-continuous-eval`, `06-hill-climbing`.
- Links the GitOps section and roadmap from `docs/README.md`.

## Decisions recorded

- Two environments: **dev -> prod** (no staging; canary in prod).
- Ship **both** hosted (container/ACR) and prompt-based (YAML bundle) agents.
- Self-hosting tracked as a spike, out of scope for the initial demo.

## Notes for reviewers

- The roadmap's gap analysis drove a set of newly filed issues (ACR module, drift detection, CODEOWNERS, tested rollback, prompt-based path, golden eval dataset, content-safety/policy gate, red teaming, per-version telemetry, self-hosted spike). The gap tables reference them.
- One gap is intentionally left untracked: the model-version upgrade playbook, flagged as a doc/runbook follow-up.
- Docs-only change; no code or infra touched.